### PR TITLE
Upgrade psalm and fix errors to fix 7.3 psalm

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require-dev": {
         "phpunit/phpunit": "^9",
         "flyeralarm/php-code-validator": "^3.2",
-        "vimeo/psalm": "^3.4"
+        "vimeo/psalm": "^4.6"
     },
     "autoload": {
         "psr-4": {

--- a/psalm.xml
+++ b/psalm.xml
@@ -34,7 +34,6 @@
         <MissingReturnType errorLevel="info" />
         <MissingPropertyType errorLevel="info" />
         <InvalidDocblock errorLevel="info" />
-        <MisplacedRequiredParam errorLevel="info" />
 
         <PropertyNotSetInConstructor errorLevel="info" />
         <MissingConstructor errorLevel="info" />

--- a/src/Client.php
+++ b/src/Client.php
@@ -296,7 +296,7 @@ class Client
      */
     public function setNamespace(string $namespace): void
     {
-        $this->namespace = (string) $namespace;
+        $this->namespace = $namespace;
     }
 
     /**

--- a/src/Connection/File.php
+++ b/src/Connection/File.php
@@ -9,7 +9,8 @@ use Domnikl\Statsd\Connection;
 class File implements Connection
 {
     /**
-     * @var null|resource|closed-resource
+     * @psalm-suppress PossiblyInvalidArgument
+     * @var null|resource
      */
     private $handle;
 
@@ -60,6 +61,7 @@ class File implements Connection
     public function close(): void
     {
         if (is_resource($this->handle)) {
+            /** @psalm-suppress InvalidPropertyAssignmentValue */
             fclose($this->handle);
         }
 

--- a/src/Connection/InetSocket.php
+++ b/src/Connection/InetSocket.php
@@ -64,7 +64,7 @@ abstract class InetSocket implements Connection
         $this->host = $host;
         $this->port = $port;
         $this->persistent = $persistent;
-        $this->maxPayloadSize = (int) $mtu -
+        $this->maxPayloadSize = $mtu -
             self::IP_HEADER_SIZE -
             $this->getProtocolHeaderSize() -
             strlen(self::LINE_DELIMITER);
@@ -144,7 +144,9 @@ abstract class InetSocket implements Connection
         if ($this->allowFragmentation()) {
             $message = join(self::LINE_DELIMITER, $messages) . self::LINE_DELIMITER;
 
-            return str_split($message, $this->maxPayloadSize);
+            $result = str_split($message, $this->maxPayloadSize);
+
+            return $result ?: [];
         }
 
         $delimiterLen = strlen(self::LINE_DELIMITER);


### PR DESCRIPTION
Psalm was failing on 7.3 for loading the bootstrap80.php file for mbstring polyfill. Not sure why it was detecting PHP 8, but was able to upgrade to latest psalm and it stopped causing that error (at least locally).