### PR TITLE
Fix composer replace for domnikl/statsd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Updated dependency to replace all legacy versions in domnikl/statsd.
 
 ## [3.1.1] - 2022-08-09
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,6 @@
         }
     },
     "replace": {
-        "domnikl/statsd": "self.version"
+        "domnikl/statsd": "<=3.0.2"
     }
 }


### PR DESCRIPTION
Updates the "replace" property in composer.json so that it properly replaces any requirements of the domnikl/statsd package.