### PR TITLE
[PHP8.4] Implicitly marking parameter $memory as nullable is deprecated

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -195,7 +195,7 @@ class Client
      * @param float $sampleRate
      * @param array $tags
      */
-    public function memory(string $key, int $memory = null, float $sampleRate = 1.0, array $tags = []): void
+    public function memory(string $key, ?int $memory = null, float $sampleRate = 1.0, array $tags = []): void
     {
         if ($memory === null) {
             $memory = memory_get_peak_usage();


### PR DESCRIPTION
Fix PHP 8.4 compatibility 

`Deprecated: Domnikl\Statsd\Client::memory(): Implicitly marking parameter $memory as nullable is deprecated, the explicit nullable type must be used instead in /app/vendor/slickdeals/statsd/src/Client.php on line 198`
