### PR TITLE
Update tests & readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@ A PHP client library for the statistics daemon ([statsd](https://github.com/etsy
 
 [![Build Status](https://github.com/slickdeals/statsd-php/workflows/Build%20statsd-php/badge.svg)](https://github.com/slickdeals/statsd-php/actions)
 
-Originally a fork of https://github.com/domnikl/statsd-php and original author Dominik Liebler. The Slickdeals team has
-taken over the project.
+Originally a fork of [domnikl/statsd-php](https://github.com/domnikl/statsd-php) and original author Dominik Liebler. The Slickdeals team has taken over the project.
 
 ## Installation
 
@@ -14,7 +13,7 @@ The best way to install statsd-php is to use Composer and add the following to y
 ```javascript
 {
     "require": {
-        "slickdeals/statsd": "~3.0"
+        "slickdeals/statsd": "^3.2"
     }
 }
 ```
@@ -38,7 +37,22 @@ $statsd->count("foo.bar", 1000);
 When establishing the connection to statsd and sending metrics, errors will be suppressed to prevent your application from crashing.
 
 If you run statsd in TCP mode, there is also a `\Domnikl\Statsd\Connection\TcpSocket` adapter that works like the `UdpSocket` except that it throws a `\Domnikl\Statsd\Connection\TcpSocketException` if no connection could be established.
-Please consider that unlike UDP, TCP is used for reliable networks and therefor exceptions (and errors) will not be suppressed in TCP mode.
+Please consider that unlike UDP, TCP is used for reliable networks and therefore exceptions (and errors) will not be suppressed in TCP mode.
+
+### Connection Timeout
+
+Both `UdpSocket` and `TcpSocket` support configurable connection timeouts. The timeout parameter accepts float values, allowing fractional second precision:
+
+```php
+<?php
+// 2.5 second timeout
+$connection = new \Domnikl\Statsd\Connection\UdpSocket('localhost', 8125, 2.5);
+
+// 500ms timeout
+$connection = new \Domnikl\Statsd\Connection\TcpSocket('localhost', 8125, 0.5);
+```
+
+If no timeout is specified, the default value from `ini_get('default_socket_timeout')` is used.
 
 ### Sampling Rate
 
@@ -101,11 +115,9 @@ statsd supports sets, so you can view the uniqueness of a given value.
 $statsd->set('userId', 1234);
 ```
 
-### disabling sending of metrics
+### Disabling Sending of Metrics
 
-To disable sending any metrics to the statsd server, you can use the `Domnikl\Statsd\Connection\Blackhole` connection
-class instead of the default socket abstraction. This may be incredibly useful for feature flags. Another options is
-to use `Domnikl\Statsd\Connection\InMemory` connection class, that will collect your messages but won't actually send them.
+To disable sending any metrics to the statsd server, you can use the `Domnikl\Statsd\Connection\Blackhole` connection class instead of the default socket abstraction. This may be incredibly useful for feature flags. Another option is to use `Domnikl\Statsd\Connection\InMemory` connection class, that will collect your messages but won't actually send them.
 
 ## StatsdAwareInterface
 

--- a/tests/unit/Connection/TcpSocketTest.php
+++ b/tests/unit/Connection/TcpSocketTest.php
@@ -11,11 +11,11 @@ class TcpSocketTest extends TestCase
 {
     public function testInit()
     {
-        $connection = new TcpSocket('localhost', 8125, 10, true);
+        $connection = new TcpSocket('localhost', 8125, 10.0, true);
 
         $this->assertEquals('localhost', $connection->getHost());
         $this->assertEquals(8125, $connection->getPort());
-        $this->assertEquals(10, $connection->getTimeout());
+        $this->assertSame(10.0, $connection->getTimeout());
         $this->assertTrue($connection->isPersistent());
     }
 
@@ -25,7 +25,7 @@ class TcpSocketTest extends TestCase
 
         $this->assertEquals('localhost', $connection->getHost());
         $this->assertEquals(8125, $connection->getPort());
-        $this->assertEquals(ini_get('default_socket_timeout'), $connection->getTimeout());
+        $this->assertSame((float) ini_get('default_socket_timeout'), $connection->getTimeout());
         $this->assertFalse($connection->isPersistent());
     }
 
@@ -34,7 +34,7 @@ class TcpSocketTest extends TestCase
         $this->expectException(\Domnikl\Statsd\Connection\TcpSocketException::class);
         $this->expectExceptionMessage('Couldn\'t connect to host "localhost:66000":');
 
-        $connection = new TcpSocket('localhost', 66000, 1);
+        $connection = new TcpSocket('localhost', 66000, 1.0);
         $connection->send('foobar');
     }
 }

--- a/tests/unit/Connection/UdpSocketTest.php
+++ b/tests/unit/Connection/UdpSocketTest.php
@@ -11,10 +11,10 @@ class UdpSocketTest extends TestCase
 {
     public function testInit()
     {
-        $connection = new UdpSocket('localhost', 8125, 10, true);
+        $connection = new UdpSocket('localhost', 8125, 10.0, true);
         $this->assertEquals('localhost', $connection->getHost());
         $this->assertEquals(8125, $connection->getPort());
-        $this->assertEquals(10, $connection->getTimeout());
+        $this->assertSame(10.0, $connection->getTimeout());
         $this->assertTrue($connection->isPersistent());
     }
 
@@ -23,7 +23,7 @@ class UdpSocketTest extends TestCase
         $connection = new UdpSocket();
         $this->assertEquals('localhost', $connection->getHost());
         $this->assertEquals(8125, $connection->getPort());
-        $this->assertEquals(ini_get('default_socket_timeout'), $connection->getTimeout());
+        $this->assertSame((float) ini_get('default_socket_timeout'), $connection->getTimeout());
         $this->assertFalse($connection->isPersistent());
     }
 }


### PR DESCRIPTION
### **PR Type**
Tests, Documentation


___

### **Description**
- Update socket timeout assertions to use float type for strict validation

- Replace assertEquals with assertSame for timeout type checking

- Add explicit float cast for ini_get('default_socket_timeout') calls

- Add Connection Timeout section with float examples and documentation

- Fix grammar, typos, and improve README accuracy

- Update version constraint from ~3.0 to ^3.2


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Socket Timeout Tests"] -->|"Change to float type"| B["TcpSocket & UdpSocket Tests"]
  A -->|"Use assertSame"| B
  C["README Documentation"] -->|"Add timeout section"| D["Connection Timeout Examples"]
  C -->|"Fix grammar & links"| E["Improved Accuracy"]
  C -->|"Update version"| F["^3.2 Constraint"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TcpSocketTest.php</strong><dd><code>Update TCP socket timeout tests to float type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unit/Connection/TcpSocketTest.php

<ul><li>Changed timeout parameter from int (10) to float (10.0) in test <br>constructors<br> <li> Replaced assertEquals with assertSame for strict float type checking <br>on timeout assertions<br> <li> Added explicit (float) cast for ini_get('default_socket_timeout') <br>comparison</ul>


</details>


  </td>
  <td><a href="https://github.com/Slickdeals/statsd-php/pull/15/files#diff-f4f6afd9248f71cc0883d27cd38d5d77c0ac449238467266cbdcd534e961ad9a">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>UdpSocketTest.php</strong><dd><code>Update UDP socket timeout tests to float type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unit/Connection/UdpSocketTest.php

<ul><li>Changed timeout parameter from int (10) to float (10.0) in test <br>constructors<br> <li> Replaced assertEquals with assertSame for strict float type checking <br>on timeout assertions<br> <li> Added explicit (float) cast for ini_get('default_socket_timeout') <br>comparison</ul>


</details>


  </td>
  <td><a href="https://github.com/Slickdeals/statsd-php/pull/15/files#diff-16940d886e4abd92afbbe74ddac518fd75603a4f48a706d63e62556a0d8d602a">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Add timeout documentation and improve README accuracy</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Converted bare URL to markdown link format for domnikl/statsd-php <br>repository<br> <li> Updated version constraint from ~3.0 to ^3.2 in composer.json example<br> <li> Fixed grammar error: changed "therefor" to "therefore"<br> <li> Added new Connection Timeout section with float examples for UdpSocket <br>and TcpSocket<br> <li> Fixed grammar: changed "options" to "option" and improved sentence <br>structure<br> <li> Standardized heading capitalization: "disabling sending of metrics" to <br>"Disabling Sending of Metrics"</ul>


</details>


  </td>
  <td><a href="https://github.com/Slickdeals/statsd-php/pull/15/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+20/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

