### PR TITLE
test: include php 8.4 and 8.5 for testing

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: [ubuntu-latest]
-        php-versions: ['7.4', '8.0', '8.1', '8.2', '8.3']
+        php-versions: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
 
     steps:
     - name: Checkout

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9",
-        "vimeo/psalm": "^5.0",
+        "vimeo/psalm": "^4.6 || ^5.0 || ^6.0",
         "friendsofphp/php-cs-fixer": "^3.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9",
-        "vimeo/psalm": "^4.6",
+        "vimeo/psalm": "^5.0",
         "friendsofphp/php-cs-fixer": "^3.0"
     },
     "autoload": {

--- a/src/Connection/InetSocket.php
+++ b/src/Connection/InetSocket.php
@@ -144,7 +144,7 @@ abstract class InetSocket implements Connection
         if ($this->allowFragmentation()) {
             $message = join(self::LINE_DELIMITER, $messages) . self::LINE_DELIMITER;
 
-            $result = str_split($message, $this->maxPayloadSize);
+            $result = str_split($message, max(1, $this->maxPayloadSize));
 
             return $result ?: [];
         }


### PR DESCRIPTION
### **PR Type**
Tests


___

### **Description**
- Add PHP 8.4 and 8.5 to CI test matrix

- Expand testing coverage for newer PHP versions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  oldMatrix["PHP 7.4-8.3"] -- "add versions" --> newMatrix["PHP 7.4-8.5"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>php.yml</strong><dd><code>Extend PHP version test matrix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/php.yml

<ul><li>Extended <code>php-versions</code> matrix to include PHP 8.4 and 8.5<br> <li> Maintains existing PHP versions 7.4, 8.0, 8.1, 8.2, 8.3<br> <li> Enables CI testing against latest PHP releases</ul>


</details>


  </td>
  <td><a href="https://github.com/Slickdeals/statsd-php/pull/17/files#diff-a73bb6555480a5ee79ae276a3f5d71a08fa316e09a4a8da7b643cf1e92c97df9">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

